### PR TITLE
fix: Remove meta.html include from default layout

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -2,7 +2,6 @@
 <html>
 <head>
     <title>{% if page.title %}{{ page.title }} – {% endif %}{{ site.name }} – {{ site.description }}</title>
-    {% include meta.html %}
     <!--[if lt IE 9]>
     <script src="http://html5shiv.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->


### PR DESCRIPTION
This resolves a build error caused by the missing _includes/meta.html file when using the local _layouts/default.html with the oneflow-jekyll-theme. The jekyll-seo-tag plugin should handle SEO metadata generation.