### PR TITLE
fix: Remove svg-icons.html include from default layout

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -27,7 +27,6 @@
             <div class="wrapper-footer">
                 <div class="container">
                     <footer class="footer">
-                        {% include svg-icons.html %} <!-- This is a Jekyll Now include, assumes it has social icons etc. -->
                                                    <!-- We can replace or augment this with our own footer content if needed. -->
                         <p>&copy; {{ site.time | date: '%Y' }} {{ site.name }}. All rights reserved.</p>
                         <p style="font-size: 0.8em; color: #777;">Particle effects by <a href="https://particles.js.org/" target="_blank" style="color: #777;">tsParticles</a></p>


### PR DESCRIPTION
This resolves a build error caused by the missing _includes/svg-icons.html file when using the local _layouts/default.html. This include was part of the old theme structure.