### PR TITLE
fix: Replace include_cached with include in layout

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -24,7 +24,7 @@
 
   <body class="layout--{{ page.layout | default: layout.layout }}{% if page.classes or layout.classes %}{{ page.classes | default: layout.classes | join: ' ' | prepend: ' ' }}{% endif %}">
     <div id="tsparticles"></div>
-    {% include_cached masthead.html %}
+    {% include masthead.html %}
 
 
     <style>
@@ -65,7 +65,7 @@
       <div id="footer" class="page__footer">
         <footer>
           {% include footer/custom.html %}
-          {% include_cached footer.html %}
+          {% include footer.html %}
           <p style="font-size: 0.8em; color: #777;">Particle effects by <a href="https://particles.js.org/" target="_blank" style="color: #777;">tsParticles</a></p>
         </footer>
       </div>


### PR DESCRIPTION
Replaces non-standard `include_cached` tags with standard `include` tags in `_layouts/default.html` to ensure compatibility with the Jekyll version used by GitHub Pages.

This should resolve the 'Unknown tag include_cached' build error.