### PR TITLE
Attempt to fix SCSS load path for remote theme

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -40,6 +40,7 @@ markdown: kramdown
 plugins:
   - jekyll-feed
   - jekyll-seo-tag # For better SEO
+  - jekyll-remote-theme
   # - jekyll-gist # If user plans to embed Gists
 
 # Exclude from processing.


### PR DESCRIPTION
Explicitly added `jekyll-remote-theme` to the plugins list in `_config.yml`. This is intended to help ensure that the SASS load paths for the `themefisher/kross-jekyll` remote theme are correctly initialized, addressing the error where the theme's `style.scss` could not import its own `variables` partial because it was looking in `jekyll-theme-primer`'s SASS directory.